### PR TITLE
Implemented `allSettled`, which waits for all promises to settle

### DIFF
--- a/RXPromise Libraries/RXPromise Libraries.xcodeproj/project.pbxproj
+++ b/RXPromise Libraries/RXPromise Libraries.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9F56AD3D1922A25800947570 /* RXSettledResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 9F56AD3B1922A25800947570 /* RXSettledResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F56AD3E1922A25800947570 /* RXSettledResult.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9F56AD3C1922A25800947570 /* RXSettledResult.mm */; };
+		9F56AD3F1922A59500947570 /* RXSettledResult.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9F56AD3C1922A25800947570 /* RXSettledResult.mm */; };
+		9F56AD401922A59500947570 /* RXSettledResult.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9F56AD3C1922A25800947570 /* RXSettledResult.mm */; };
+		9F56AD411922A65F00947570 /* RXSettledResult.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F56AD3B1922A25800947570 /* RXSettledResult.h */; };
+		9F56AD421922A66500947570 /* RXSettledResult.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F56AD3B1922A25800947570 /* RXSettledResult.h */; };
 		A124D1EE182F902300F35B28 /* RXPromise+RXExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = A124D1EC182F902300F35B28 /* RXPromise+RXExtension.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A124D1EF182F902300F35B28 /* RXPromise+RXExtension.mm in Sources */ = {isa = PBXBuildFile; fileRef = A124D1ED182F902300F35B28 /* RXPromise+RXExtension.mm */; };
 		A124D1F0182F902300F35B28 /* RXPromise+RXExtension.mm in Sources */ = {isa = PBXBuildFile; fileRef = A124D1ED182F902300F35B28 /* RXPromise+RXExtension.mm */; };
@@ -35,6 +41,7 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				9F56AD411922A65F00947570 /* RXSettledResult.h in CopyFiles */,
 				A1A5811F18F0310F00A00242 /* RXPromise.h in CopyFiles */,
 				A129D01F182FB831008E6DA1 /* RXPromise+RXExtension.h in CopyFiles */,
 			);
@@ -46,6 +53,7 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				9F56AD421922A66500947570 /* RXSettledResult.h in CopyFiles */,
 				A1A5812018F0312600A00242 /* RXPromise.h in CopyFiles */,
 				A129D020182FB83B008E6DA1 /* RXPromise+RXExtension.h in CopyFiles */,
 			);
@@ -54,6 +62,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		9F56AD3B1922A25800947570 /* RXSettledResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RXSettledResult.h; sourceTree = "<group>"; };
+		9F56AD3C1922A25800947570 /* RXSettledResult.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RXSettledResult.mm; sourceTree = "<group>"; };
 		A124D1EC182F902300F35B28 /* RXPromise+RXExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RXPromise+RXExtension.h"; sourceTree = "<group>"; };
 		A124D1ED182F902300F35B28 /* RXPromise+RXExtension.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "RXPromise+RXExtension.mm"; sourceTree = "<group>"; };
 		A124D1F2182F942D00F35B28 /* RXPromise+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RXPromise+Private.h"; sourceTree = "<group>"; };
@@ -214,6 +224,8 @@
 				A124D1EC182F902300F35B28 /* RXPromise+RXExtension.h */,
 				A124D1ED182F902300F35B28 /* RXPromise+RXExtension.mm */,
 				A124D1F2182F942D00F35B28 /* RXPromise+Private.h */,
+				9F56AD3B1922A25800947570 /* RXSettledResult.h */,
+				9F56AD3C1922A25800947570 /* RXSettledResult.mm */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -234,6 +246,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A124D1F4182F942D00F35B28 /* RXPromise+Private.h in Headers */,
+				9F56AD3D1922A25800947570 /* RXSettledResult.h in Headers */,
 				A1A5811E18F030D400A00242 /* RXPromise.h in Headers */,
 				A124D1EE182F902300F35B28 /* RXPromise+RXExtension.h in Headers */,
 				A19C19D81759EA3B008E3F63 /* DLog.h in Headers */,
@@ -340,6 +353,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A19C19D51759EA3B008E3F63 /* RXPromise.mm in Sources */,
+				9F56AD3E1922A25800947570 /* RXSettledResult.mm in Sources */,
 				A124D1EF182F902300F35B28 /* RXPromise+RXExtension.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -349,6 +363,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A19C19D61759EA3B008E3F63 /* RXPromise.mm in Sources */,
+				9F56AD3F1922A59500947570 /* RXSettledResult.mm in Sources */,
 				A124D1F0182F902300F35B28 /* RXPromise+RXExtension.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -358,6 +373,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A129D0211830095C008E6DA1 /* RXPromise+RXExtension.mm in Sources */,
+				9F56AD401922A59500947570 /* RXSettledResult.mm in Sources */,
 				A19C19D71759EA3B008E3F63 /* RXPromise.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RXPromise Libraries/Source/RXPromise+RXExtension.h
+++ b/RXPromise Libraries/Source/RXPromise+RXExtension.h
@@ -110,12 +110,34 @@ typedef RXPromise* (^rxp_nullary_task)();
  @warning The promise is rejected with reason \c \@"parameter error" if
  the parameter @p promises is \c nil or empty.
  
- @return A new promise. 
- 
+ @return A new promise.
  */
 + (instancetype)all:(NSArray*)promises NS_RETURNS_RETAINED;
 
 
+/**
+ @brief Method \c allSettled returns a \p RXPromise object which will be resolved when \a all
+ promises in the array @p promises are fulfilled or all are rejected.
+ 
+ @discussion In contrast to \c all, which resolves as soon as one of the promises
+ has been rejected, \c allSettled waits until all promises have resolved before
+ proceeding. The promise will be fulfilled as long \c allSettled was provided with
+ valid params. The parameter @p result of the completion handler will be an array
+ of RXSettledResult objects. Each will have either isFulfilled or isRejected set to
+ true, and the result property will hold the fulfillment value or rejection reason.
+ 
+ @par \b Caution:
+ The completion handler's return value MUST NOT be \c nil. This is due the restriction
+ of \c NSArrays which cannot contain \c nil values.
+ 
+ @param promises A @c NSArray containing promises.
+ 
+ @warning The promise is rejected with reason \c \@"parameter error" if
+ the parameter @p promises is \c nil or empty.
+ 
+ @return A new promise.
+ */
++ (instancetype)allSettled:(NSArray*)promises NS_RETURNS_RETAINED;
 
 /*!
  @brief Method \p any returns a \c RXPromise object which will be resolved when

--- a/RXPromise Libraries/Source/RXPromise+RXExtension.mm
+++ b/RXPromise Libraries/Source/RXPromise+RXExtension.mm
@@ -17,6 +17,7 @@
 
 #import "RXPromise+RXExtension.h"
 #import "RXPromise.h"
+#import "RXSettledResult.h"
 #import "RXPromise+Private.h"
 #if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
     #import <UIKit/UIKit.h>
@@ -138,6 +139,34 @@ namespace {
     };
     for (RXPromise* p in promises) {
         p.thenOn(Shared.sync_queue, onSuccess, onError);
+    }
+    return promise;
+}
+
++(instancetype) allSettled:(NSArray*)promises
+{
+    RXPromise* promise = [[self alloc] init];
+    __block NSUInteger count = [promises count];
+    if (count == 0) {
+        [promise rejectWithReason:@"parameter error"];
+        return promise;
+    }
+    __weak RXPromise* weakPromise = promise;
+    promise_completionHandler_t onSuccess = ^id(id result) {
+        --count;
+        RXPromise* strongPromise = weakPromise;
+        if (count == 0 and strongPromise) {
+            NSMutableArray* results = [[NSMutableArray alloc] initWithCapacity:[promises count]];
+            for (RXPromise* p in promises) {
+                RXSettledResult *result = [[RXSettledResult alloc] initWithFulfilled:p.isFulfilled andResult:[p synced_peakResult]];
+                [results addObject:result];
+            }
+            [strongPromise fulfillWithValue:results];
+        }
+        return nil;
+    };
+    for (RXPromise* p in promises) {
+        p.thenOn(Shared.sync_queue, onSuccess, onSuccess);
     }
     return promise;
 }

--- a/RXPromise Libraries/Source/RXPromise.h
+++ b/RXPromise Libraries/Source/RXPromise.h
@@ -17,7 +17,6 @@
 
 #import <Foundation/Foundation.h>
 
-
 /*
  
  A RXPromise object represents the eventual result of an asynchronous function

--- a/RXPromise Libraries/Source/RXSettledResult.h
+++ b/RXPromise Libraries/Source/RXSettledResult.h
@@ -1,0 +1,19 @@
+//
+//  RXSettledResult.h
+//  RXPromise Libraries
+//
+//  Created by Luke Melia on 5/13/14.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface RXSettledResult : NSObject
+
+@property (nonatomic, assign, readonly, getter=isFulfilled) BOOL fulfilled;
+@property (nonatomic, assign, readonly, getter=isRejected) BOOL rejected;
+@property (readonly, nonatomic) id result;
+
+-(instancetype)initWithFulfilled:(BOOL)isFulfilled andResult:(id)valueOrReason;
+
+@end

--- a/RXPromise Libraries/Source/RXSettledResult.mm
+++ b/RXPromise Libraries/Source/RXSettledResult.mm
@@ -1,0 +1,34 @@
+//
+//  RXSettledResult.m
+//  RXPromise Libraries
+//
+//  Created by Luke Melia on 5/13/14.
+//
+//
+
+#import "RXSettledResult.h"
+
+@implementation RXSettledResult {
+    BOOL _fulfilled;
+    id _result;
+}
+
+-(instancetype)initWithFulfilled:(BOOL)isFulfilled andResult:(id)valueOrReason;
+{
+    self = [super init];
+    if (self) {
+        _fulfilled = isFulfilled;
+        _result = valueOrReason;
+    }
+    return self;
+}
+
+-(BOOL) isFulfilled {
+    return _fulfilled;
+}
+
+-(BOOL) isRejected {
+    return !_fulfilled;
+}
+
+@end

--- a/RXPromise.xcworkspace/xcshareddata/RXPromise.xccheckout
+++ b/RXPromise.xcworkspace/xcshareddata/RXPromise.xccheckout
@@ -5,34 +5,34 @@
 	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
 	<false/>
 	<key>IDESourceControlProjectIdentifier</key>
-	<string>D4D84DC7-27BC-46C6-9C7F-F40443C47CFB</string>
+	<string>2972F297-1761-49A4-9EC6-1BEEFAAEF5EA</string>
 	<key>IDESourceControlProjectName</key>
 	<string>RXPromise</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
-		<key>C6D05B39-31EA-4BF9-B515-A8A875F0C3F3</key>
-		<string>https://github.com/couchdeveloper/RXPromise.git</string>
+		<key>E2710297-F416-4D15-A82E-A75A5248FE5B</key>
+		<string>ssh://github.com/yapplabs/RXPromise.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
 	<string>RXPromise.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
-		<key>C6D05B39-31EA-4BF9-B515-A8A875F0C3F3</key>
+		<key>E2710297-F416-4D15-A82E-A75A5248FE5B</key>
 		<string>..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>https://github.com/couchdeveloper/RXPromise.git</string>
+	<string>ssh://github.com/yapplabs/RXPromise.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>110</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>
-	<string>C6D05B39-31EA-4BF9-B515-A8A875F0C3F3</string>
+	<string>E2710297-F416-4D15-A82E-A75A5248FE5B</string>
 	<key>IDESourceControlProjectWCConfigurations</key>
 	<array>
 		<dict>
 			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
 			<string>public.vcs.git</string>
 			<key>IDESourceControlWCCIdentifierKey</key>
-			<string>C6D05B39-31EA-4BF9-B515-A8A875F0C3F3</string>
+			<string>E2710297-F416-4D15-A82E-A75A5248FE5B</string>
 			<key>IDESourceControlWCCName</key>
 			<string>RXPromise</string>
 		</dict>


### PR DESCRIPTION
This PR implements `allSettled`, which waits for all promises in the provided array to fulfill or resolve and then fulfills with an array of RXSettledResult objects. Inspiration from http://emberjs.com/api/classes/Ember.RSVP.html#method_allSettled
