### PR TITLE
 Make it so that repeat: can terminate on nil OR an object and return that.

### DIFF
--- a/RXPromise Libraries/Source/RXPromise+RXExtension.h
+++ b/RXPromise Libraries/Source/RXPromise+RXExtension.h
@@ -49,7 +49,7 @@ typedef RXPromise* (^rxp_unary_task)(id input);
  */
 typedef RXPromise* (^rxp_nullary_task)();
 
-
+typedef id (^rxp_or_object_nullary_task)();
 
 
 @interface RXPromise (RXExtension)

--- a/Samples/Sample7/main.m
+++ b/Samples/Sample7/main.m
@@ -50,9 +50,9 @@ RXPromise* performTasksWithArray(NSArray* inputs)
 {
     const NSUInteger count = [inputs count];
     __block NSUInteger i = 0;
-    return [RXPromise repeat:^RXPromise*{
+    return [RXPromise repeat:^id{
         if (i >= count) {
-            return nil;
+            return @"final value";
         }
         return [inputs[i++] asyncTask].then(^id(id result){
             NSLog(@"%@", result);

--- a/Test/Tests/RXPromiseTest.mm
+++ b/Test/Tests/RXPromiseTest.mm
@@ -4627,6 +4627,29 @@ static RXPromise* asyncOp(NSString* label, int workCount, NSOperationQueue* queu
     XCTAssertTrue([resultString isEqualToString:@"ABCDEFG"], @"");
 }
 
+- (void) testRepeatWithResult
+{
+    NSArray* inputs = @[@"a", @"b", @"c", @"d", @"e", @"f", @"g"];
+    NSMutableString* resultString = [[NSMutableString alloc] init];
+    const NSUInteger count = [inputs count];
+    __block NSUInteger i = 0;
+    [[RXPromise repeat:^id{
+        if (i >= count) {
+            return resultString;
+        }
+        return [RXPromise promiseWithTask:^id{
+            NSString* str = [inputs[i++] capitalizedString];
+            [resultString appendString:str];
+            return @"OK";
+        }];
+    }].then(^id(id result) {
+        XCTAssertTrue([resultString isEqualToString:result], @"");
+        return result;
+    }, nil) runLoopWait];
+    
+    XCTAssertTrue([resultString isEqualToString:@"ABCDEFG"], @"");
+}
+
 - (void) testRepeatWithCancellation
 {
     NSMutableString* resultString = [[NSMutableString alloc] init];


### PR DESCRIPTION
Hi @couchdeveloper,

This is a small pull request that makes it so that `repeat:` behaves slightly differently (and more consistently with `then` say). Instead of terminating on `nil` and returning a constant, it terminates if and only if the value returned from a repeat block is not a promise. Furthermore, when the termination occurs the result is returned up the chain. 

I'd like to get some feedback from you. My plan is to use this in my own code, in order to poll a webservice (may take a few repetitions) and then return the result. 

What do you think?

Thanks,

Dmitry
